### PR TITLE
Adding strict validation for unsupported query parameters for all endpoints

### DIFF
--- a/app/routers/associations.py
+++ b/app/routers/associations.py
@@ -8,6 +8,8 @@ from sqlalchemy.orm import Session
 from app.core.exceptions import handle_database_error
 from app.db.database import get_db
 
+from app.utils.validate_query import validate_query_params
+
 router = APIRouter(prefix="/associations", tags=["associations"])
 
 
@@ -19,6 +21,21 @@ router = APIRouter(prefix="/associations", tags=["associations"])
         "Paginated list of disease-target pairs with metrics. "
         "Optional filters: doid, gene_symbol, uniprot, idgtdl, min_score, limit, offset."
     ),
+    dependencies=[
+        Depends(
+            validate_query_params(
+                {
+                    "doid",
+                    "gene_symbol",
+                    "uniprot",
+                    "idgtdl",
+                    "min_score",
+                    "limit",
+                    "offset",
+                }
+            )
+        )
+    ],
 )
 def associations_summary(
     # important: doid input is following: e.g. DOID:1799
@@ -119,6 +136,25 @@ def associations_summary(
     "/evidence",
     summary="Evidence-level rows linking disease-target-drug-study (main provenance surface)",
     description="Paginated evidence rows including: DOID/name, UniProt/gene/TDL, drug (molecule_chembl_id, cid, drug_name), study (nct_id, title, phase, status, dates, enrollment, study_url)",
+    dependencies=[
+        Depends(
+            validate_query_params(
+                {
+                    "doid",
+                    "uniprot",
+                    "disease_name",
+                    "gene_symbol",
+                    "molecule_chembl_id",
+                    "nct_id",
+                    "phase",
+                    "overall_status",
+                    "exclude_withdrawn",
+                    "limit",
+                    "offset",
+                }
+            )
+        )
+    ],
 )
 def associations_evidence(
     # Disease target in the docs but using doid and uniprot
@@ -238,6 +274,21 @@ def associations_evidence(
     "/provenance_summary",
     summary="Disease-target pairs with trial evidence and publication",
     description="Endpoint which shows disease-target pairs that have linked clinical trials and publication (provenance)",
+    dependencies=[
+        Depends(
+            validate_query_params(
+                {
+                    "doid",
+                    "gene_symbol",
+                    "uniprot",
+                    "nct_id",
+                    "pmid",
+                    "limit",
+                    "offset",
+                }
+            )
+        )
+    ],
 )
 def provenance_summary(
     doid: str | None = None,

--- a/app/routers/diseases.py
+++ b/app/routers/diseases.py
@@ -6,6 +6,9 @@ from sqlalchemy.orm import Session
 from app.core.exceptions import handle_database_error
 from app.db.database import get_db
 
+from app.utils.validate_query import validate_query_params
+
+
 router = APIRouter(prefix="/diseases", tags=["diseases"])
 
 
@@ -14,6 +17,16 @@ router = APIRouter(prefix="/diseases", tags=["diseases"])
     "/search",
     summary="Typeahead / lookup for diseases",
     description="Typeahead / lookup for diseases",
+    dependencies=[
+        Depends(
+            validate_query_params(
+                {
+                    "q",
+                    "limit",
+                }
+            )
+        )
+    ],
 )
 def search_diseases(
     q: str = Query(..., description="Substring search"),

--- a/app/routers/drugs.py
+++ b/app/routers/drugs.py
@@ -6,6 +6,8 @@ from sqlalchemy import text
 from app.core.exceptions import handle_database_error
 from app.db.database import get_db
 
+from app.utils.validate_query import validate_query_params
+
 
 router = APIRouter(prefix="/drugs", tags=["drugs"])
 
@@ -15,6 +17,16 @@ router = APIRouter(prefix="/drugs", tags=["drugs"])
     "/search",
     summary="Typeahead / lookup for drugs",
     description="Typeahead / lookup for drugs",
+    dependencies=[
+        Depends(
+            validate_query_params(
+                {
+                    "q",
+                    "limit",
+                }
+            )
+        )
+    ],
 )
 def search_drugs(
     q: str = Query(..., description="Drug name substring"),

--- a/app/routers/meta.py
+++ b/app/routers/meta.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 from app.core.exceptions import handle_database_error
 from app.db.database import get_db
 
+
 router = APIRouter(prefix="/meta", tags=["meta"])
 
 
@@ -28,7 +29,9 @@ def health():
 def counts(db: Session = Depends(get_db)):
     try:
         # counts
-        disease_count = db.execute(text("SELECT COUNT(*) FROM core.disease")).scalar_one()
+        disease_count = db.execute(
+            text("SELECT COUNT(*) FROM core.disease")
+        ).scalar_one()
         target_count = db.execute(text("SELECT COUNT(*) FROM core.target")).scalar_one()
         drug_count = db.execute(text("SELECT COUNT(*) FROM core.drug")).scalar_one()
         study_count = db.execute(text("SELECT COUNT(*) FROM core.study")).scalar_one()

--- a/app/routers/publications.py
+++ b/app/routers/publications.py
@@ -6,6 +6,9 @@ from sqlalchemy.orm import Session
 from app.core.exceptions import handle_database_error
 from app.db.database import get_db
 
+from app.utils.validate_query import validate_query_params
+
+
 router = APIRouter(prefix="/publications", tags=["publications"])
 
 
@@ -14,6 +17,7 @@ router = APIRouter(prefix="/publications", tags=["publications"])
     "/{pmid}",
     summary="Publication details + PubMed link-out",
     description="Publication details + PubMed link-out",
+    dependencies=[Depends(validate_query_params(set()))],
 )
 def get_publication(pmid: str, db: Session = Depends(get_db)):
     """ """

--- a/app/routers/studies.py
+++ b/app/routers/studies.py
@@ -8,6 +8,9 @@ from sqlalchemy.orm import Session
 from app.core.exceptions import handle_database_error
 from app.db.database import get_db
 
+from app.utils.validate_query import validate_query_params
+
+
 router = APIRouter(prefix="/studies", tags=["studies"])
 
 
@@ -16,6 +19,7 @@ router = APIRouter(prefix="/studies", tags=["studies"])
     "/search",
     summary="Typeahead / lookup for studies",
     description="Typeahead / lookup for studies",
+    dependencies=[Depends(validate_query_params({"q", "limit"}))],
 )
 def search_studies(
     q: str = Query(..., description="NCT or title substring"),
@@ -58,6 +62,7 @@ def search_studies(
     "/{nct_id}",
     summary="Fetch a single study's metadata + ClinicalTrials.gov link-out",
     description="Fetch a single study's metadata + ClinicalTrials.gov link-out",
+    dependencies=[Depends(validate_query_params(set()))],
 )
 def get_study(nct_id: str, db: Session = Depends(get_db)):
     # e.g. NCT00137111, NCT00635258, NCT00340262, NCT01501019, NCT03912506
@@ -119,6 +124,7 @@ def get_study(nct_id: str, db: Session = Depends(get_db)):
     "/{nct_id}/publications",
     summary="Publications supporting a given study (NCT -> PMIDs)",
     description="Publications supporting a given study (NCT -> PMIDs)",
+    dependencies=[Depends(validate_query_params(set()))],
 )
 def study_publications(nct_id: str, db: Session = Depends(get_db)):
     """

--- a/app/routers/targets.py
+++ b/app/routers/targets.py
@@ -6,6 +6,8 @@ from sqlalchemy import text
 from app.core.exceptions import handle_database_error
 from app.db.database import get_db
 
+from app.utils.validate_query import validate_query_params
+
 
 router = APIRouter(prefix="/targets", tags=["targets"])
 
@@ -15,6 +17,7 @@ router = APIRouter(prefix="/targets", tags=["targets"])
     "/search",
     summary="Typeahead / lookup for targets",
     description="Typeahead / lookup for targets",
+    dependencies=[Depends(validate_query_params({"q", "limit"}))],
 )
 def search_targets(
     q: str = Query(..., description="Gene symbol or UniProt substring"),

--- a/app/utils/validate_query.py
+++ b/app/utils/validate_query.py
@@ -1,0 +1,15 @@
+from fastapi import Request, HTTPException
+
+
+def validate_query_params(allowed: set[str]):
+    async def _validate(request: Request):
+        # if the request includes some of allowed params, extra is empty, otherwise 400
+        extra = set(request.query_params.keys()) - allowed
+
+        if extra:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid query parameters: {', '.join(sorted(extra))}",
+            )
+
+    return _validate


### PR DESCRIPTION
Fixes #11 

Added shared validator in utils/ and applied to endpoints with query params. Returns 400 for unsupported params.

Example:
curl "http://127.0.0.1:8000/api/v1/associations/summary?limit=5&bad_param=123"
{"detail":"Invalid query parameters: bad_param"}